### PR TITLE
Check and external subcommands

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,8 @@ command -globalopt subcommand -subopt1 FOO -subopt2 ARG1 ARG2
 ```
 
 Subcommands may have sub-subcommands and so on.
+Subcommands may also be implemented as separate executables.
+(See the documentation for [Prefixer](https://pkg.go.dev/github.com/bobg/subcmd/v2#Prefixer).)
 
 This is a layer on top of the standard Go `flag` package.
 

--- a/check.go
+++ b/check.go
@@ -11,14 +11,14 @@ import (
 
 // Check performs type checking on subcmd as follows:
 //
-//  - It checks that subcmd.F is a function and returns ErrNotAFunction if it isn't.
-//  - It checks that subcmd.F returns no more than one value and returns ErrTooManyReturns if it doesn't.
-//  - It checks that the type of the value returned by subcmd.F (if any) is error and returns ErrNotError if it isn't.
-//  - It checks that subcmd.F takes an initial context.Context parameter and returns ErrNoContext if it doesn't.
-//  - It checks that subcmd.F takes a final []string parameter and returns ErrNoStringSlice if it doesn't.
-//  - It checks that the length of subcmd.Params matches the number of parameters subcmd.F takes (not counting the initial context.Context and final []string parameters) and returns a NumParamsErr if it doesn't.
-//  - It checks that each parameter in subcmd.Params matches the corresponding parameter in subcmd.F and returns a ParamTypeErr if it doesn't.
-//  - It checks that the default value of each parameter in subcmd.Params matches the parameter's type and returns a ParamDefaultErr if it doesn't.
+//   - It checks that subcmd.F is a function and returns ErrNotAFunction if it isn't.
+//   - It checks that subcmd.F returns no more than one value and returns ErrTooManyReturns if it doesn't.
+//   - It checks that the type of the value returned by subcmd.F (if any) is error and returns ErrNotError if it isn't.
+//   - It checks that subcmd.F takes an initial context.Context parameter and returns ErrNoContext if it doesn't.
+//   - It checks that subcmd.F takes a final []string parameter and returns ErrNoStringSlice if it doesn't.
+//   - It checks that the length of subcmd.Params matches the number of parameters subcmd.F takes (not counting the initial context.Context and final []string parameters) and returns a NumParamsErr if it doesn't.
+//   - It checks that each parameter in subcmd.Params matches the corresponding parameter in subcmd.F and returns a ParamTypeErr if it doesn't.
+//   - It checks that the default value of each parameter in subcmd.Params matches the parameter's type and returns a ParamDefaultErr if it doesn't.
 //
 // Only the first error encountered is returned.
 func Check(subcmd Subcmd) error {
@@ -89,108 +89,56 @@ func CheckMap(m Map) error {
 func checkParam(ft reflect.Type, n int, want Type) error {
 	var (
 		paramType = ft.In(n)
-		errType   reflect.Type
+		argType   reflect.Type
 	)
 
 	switch want {
 	case Bool:
-		var (
-			x  bool
-			xt = reflect.TypeOf(x)
-		)
-		if !xt.AssignableTo(paramType) {
-			errType = xt
-		}
+		var x bool
+		argType = reflect.TypeOf(x)
 
 	case Int:
-		var (
-			x  int
-			xt = reflect.TypeOf(x)
-		)
-		if !xt.AssignableTo(paramType) {
-			errType = xt
-		}
+		var x int
+		argType = reflect.TypeOf(x)
 
 	case Int64:
-		var (
-			x  int64
-			xt = reflect.TypeOf(x)
-		)
-		if !xt.AssignableTo(paramType) {
-			errType = xt
-		}
+		var x int64
+		argType = reflect.TypeOf(x)
 
 	case Uint:
-		var (
-			x  uint
-			xt = reflect.TypeOf(x)
-		)
-		if !xt.AssignableTo(paramType) {
-			errType = xt
-		}
+		var x uint
+		argType = reflect.TypeOf(x)
 
 	case Uint64:
-		var (
-			x  uint64
-			xt = reflect.TypeOf(x)
-		)
-		if !xt.AssignableTo(paramType) {
-			errType = xt
-		}
+		var x uint64
+		argType = reflect.TypeOf(x)
 
 	case String:
-		var (
-			x  string
-			xt = reflect.TypeOf(x)
-		)
-		if !xt.AssignableTo(paramType) {
-			errType = xt
-		}
+		var x string
+		argType = reflect.TypeOf(x)
 
 	case Float64:
-		var (
-			x  float64
-			xt = reflect.TypeOf(x)
-		)
-		if !xt.AssignableTo(paramType) {
-			errType = xt
-		}
+		var x float64
+		argType = reflect.TypeOf(x)
 
 	case Duration:
-		var (
-			x  time.Duration
-			xt = reflect.TypeOf(x)
-		)
-		if !xt.AssignableTo(paramType) {
-			errType = xt
-		}
+		var x time.Duration
+		argType = reflect.TypeOf(x)
 
 	case contextType:
-		var (
-			x  = context.Background() // Need a concrete value, not a nil interface.
-			xt = reflect.TypeOf(x)
-		)
-		if !xt.AssignableTo(paramType) {
-			// Special case.
-			return ErrNoContext
-		}
+		var x = context.Background() // Need a concrete value, not a nil interface.
+		argType = reflect.TypeOf(x)
 
 	case stringSliceType:
-		var (
-			x  []string
-			xt = reflect.TypeOf(x)
-		)
-		if !xt.AssignableTo(paramType) {
-			// Special case.
-			return ErrNoStringSlice
-		}
+		var x []string
+		argType = reflect.TypeOf(x)
 
 	default:
 		return fmt.Errorf("unknown type %v", want)
 	}
 
-	if errType != nil {
-		return ParamTypeErr{N: n, Want: want, Got: errType}
+	if !argType.AssignableTo(paramType) {
+		return ParamTypeErr{N: n, Want: want, Got: paramType}
 	}
 
 	return nil

--- a/check.go
+++ b/check.go
@@ -1,0 +1,131 @@
+package subcmd
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// Check checks that the type of subcmd.F matches the list of parameters in subcmd.Params.
+func Check(subcmd Subcmd) error {
+	fv := reflect.ValueOf(subcmd.F)
+	ft := fv.Type()
+	if ft.Kind() != reflect.Func {
+		return fmt.Errorf("F is not a function")
+	}
+	numIn := ft.NumIn()
+	if numIn != len(subcmd.Params)+2 {
+		return fmt.Errorf("F has %d parameters, want %d", numIn, len(subcmd.Params)+2)
+	}
+
+	if err := checkParam(ft, 0, contextType); err != nil {
+		return errors.Wrap(err, "checking first parameter is a context.Context")
+	}
+	if err := checkParam(ft, numIn-1, stringSliceType); err != nil {
+		return errors.Wrap(err, "checking last parameter is []string")
+	}
+
+	for i, param := range subcmd.Params {
+		if err := checkParam(ft, i+1, param.Type); err != nil {
+			return errors.Wrapf(err, "checking parameter %d", i+1)
+		}
+	}
+
+	numOut := ft.NumOut()
+	switch numOut {
+	case 0:
+		// ok
+	case 1:
+		if !ft.Out(0).Implements(errType) {
+			return fmt.Errorf("return type is not error")
+		}
+	default:
+		return fmt.Errorf("F returns %d values, want 0 or 1", numOut)
+	}
+
+	return nil
+}
+
+// CheckMap calls Check on each of the entries in the Map.
+func CheckMap(m Map) error {
+	for name, subcmd := range m {
+		if err := Check(subcmd); err != nil {
+			return errors.Wrapf(err, "checking subcommand %s", name)
+		}
+	}
+	return nil
+}
+
+func checkParam(ft reflect.Type, n int, want Type) error {
+	paramType := ft.In(n)
+
+	switch want {
+	case Bool:
+		var x bool
+		if !reflect.TypeOf(x).AssignableTo(paramType) {
+			return fmt.Errorf("parameter %d is %s, want bool", n, paramType)
+		}
+
+	case Int:
+		var x int
+		if !reflect.TypeOf(x).AssignableTo(paramType) {
+			return fmt.Errorf("parameter %d is %s, want int", n, paramType)
+		}
+
+	case Int64:
+		var x int64
+		if !reflect.TypeOf(x).AssignableTo(paramType) {
+			return fmt.Errorf("parameter %d is %s, want int64", n, paramType)
+		}
+
+	case Uint:
+		var x uint
+		if !reflect.TypeOf(x).AssignableTo(paramType) {
+			return fmt.Errorf("parameter %d is %s, want uint", n, paramType)
+		}
+
+	case Uint64:
+		var x uint64
+		if !reflect.TypeOf(x).AssignableTo(paramType) {
+			return fmt.Errorf("parameter %d is %s, want uint64", n, paramType)
+		}
+
+	case String:
+		var x string
+		if !reflect.TypeOf(x).AssignableTo(paramType) {
+			return fmt.Errorf("parameter %d is %s, want string", n, paramType)
+		}
+
+	case Float64:
+		var x float64
+		if !reflect.TypeOf(x).AssignableTo(paramType) {
+			return fmt.Errorf("parameter %d is %s, want float64", n, paramType)
+		}
+
+	case Duration:
+		var x time.Duration
+		if !reflect.TypeOf(x).AssignableTo(paramType) {
+			return fmt.Errorf("parameter %d is %s, want time.Duration", n, paramType)
+		}
+
+	case contextType:
+		x := context.Background() // Need a concrete value, not a nil interface.
+		if !reflect.TypeOf(x).AssignableTo(paramType) {
+			return fmt.Errorf("parameter %d is %s, want context.Context", n, paramType)
+		}
+
+	case stringSliceType:
+		var x []string
+		if !reflect.TypeOf(x).AssignableTo(paramType) {
+			return fmt.Errorf("parameter %d is %s, want []string", n, paramType)
+		}
+
+	default:
+		return fmt.Errorf("unknown type %v", want)
+	}
+
+	return nil
+}

--- a/check_test.go
+++ b/check_test.go
@@ -1,0 +1,73 @@
+package subcmd
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCheck(t *testing.T) {
+	cases := []struct {
+		name    string
+		f       interface{}
+		ptypes  []Type
+		wantErr bool
+	}{{
+		name: "noParamsOK",
+		f:    checkNoParams,
+	}, {
+		name:    "noParamsBad",
+		f:       checkNoParams,
+		ptypes:  []Type{Bool},
+		wantErr: true,
+	}, {
+		name: "noParamsNoErrOK",
+		f:    checkNoParamsNoErr,
+	}, {
+		name:    "noParamsNoErrBad",
+		f:       checkNoParamsNoErr,
+		ptypes:  []Type{Bool},
+		wantErr: true,
+	}, {
+		name:   "oneBoolFlagOK",
+		f:      checkOneBoolFlag,
+		ptypes: []Type{Bool},
+	}, {
+		name:    "oneBoolFlagTooMany",
+		f:       checkOneBoolFlag,
+		ptypes:  []Type{Bool, Bool},
+		wantErr: true,
+	}, {
+		name:    "oneBoolFlagTooFew",
+		f:       checkOneBoolFlag,
+		wantErr: true,
+	}, {
+		name:    "oneBoolFlagWrongType",
+		f:       checkOneBoolFlag,
+		ptypes:  []Type{Int},
+		wantErr: true,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var params []Param
+			for _, ptype := range tc.ptypes {
+				params = append(params, Param{Type: ptype})
+			}
+			err := Check(Subcmd{F: tc.f, Params: params})
+			switch {
+			case err == nil && tc.wantErr:
+				t.Error("got no error but want one")
+			case err != nil && !tc.wantErr:
+				t.Error(err)
+			}
+		})
+	}
+}
+
+func checkNoParamsNoErr(_ context.Context, _ []string) {}
+
+func checkNoParams(_ context.Context, _ []string) error {
+	return nil
+}
+
+func checkOneBoolFlag(_ context.Context, _ bool, _ []string) {}

--- a/check_test.go
+++ b/check_test.go
@@ -130,3 +130,33 @@ func TestCheckOneArg(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckNotFunc(t *testing.T) {
+	if err := Check(Subcmd{F: 42}); !errors.Is(err, ErrNotAFunction) {
+		t.Errorf("got %v, want ErrNotAFunction", err)
+	}
+}
+
+func TestCheckNoContext(t *testing.T) {
+	if err := Check(Subcmd{F: func(int, []string) {}}); !errors.Is(err, ErrNoContext) {
+		t.Errorf("got %v, want ErrNoContext", err)
+	}
+}
+
+func TestCheckNoStringSlice(t *testing.T) {
+	if err := Check(Subcmd{F: func(context.Context, int) {}}); !errors.Is(err, ErrNoStringSlice) {
+		t.Errorf("got %v, want ErrNoStringSlice", err)
+	}
+}
+
+func TestCheckNoError(t *testing.T) {
+	if err := Check(Subcmd{F: func(context.Context, []string) int { return 0 }}); !errors.Is(err, ErrNotError) {
+		t.Errorf("got %v, want ErrNotError", err)
+	}
+}
+
+func TestTooManyReturns(t *testing.T) {
+	if err := Check(Subcmd{F: func(context.Context, []string) (int, int) { return 0, 0 }}); !errors.Is(err, ErrTooManyReturns) {
+		t.Errorf("got %v, want ErrTooManyReturns", err)
+	}
+}

--- a/check_test.go
+++ b/check_test.go
@@ -124,28 +124,28 @@ func TestCheckNotFunc(t *testing.T) {
 func TestCheckNoContext(t *testing.T) {
 	var e FuncTypeErr
 	if err := Check(Subcmd{F: func(int, []string) {}}); !errors.As(err, &e) {
-		t.Errorf("got %v, want ErrNoContext", err)
+		t.Errorf("got %v, want FuncTypeErr", err)
 	}
 }
 
 func TestCheckNoStringSlice(t *testing.T) {
 	var e FuncTypeErr
 	if err := Check(Subcmd{F: func(context.Context, int) {}}); !errors.As(err, &e) {
-		t.Errorf("got %v, want ErrNoStringSlice", err)
+		t.Errorf("got %v, want FuncTypeErr", err)
 	}
 }
 
 func TestCheckNoError(t *testing.T) {
 	var e FuncTypeErr
 	if err := Check(Subcmd{F: func(context.Context, []string) int { return 0 }}); !errors.As(err, &e) {
-		t.Errorf("got %v, want ErrNotError", err)
+		t.Errorf("got %v, want FuncTypeErr", err)
 	}
 }
 
 func TestTooManyReturns(t *testing.T) {
 	var e FuncTypeErr
 	if err := Check(Subcmd{F: func(context.Context, []string) (int, int) { return 0, 0 }}); !errors.As(err, &e) {
-		t.Errorf("got %v, want ErrTooManyReturns", err)
+		t.Errorf("got %v, want FuncTypeErr", err)
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 )
 
@@ -213,4 +214,42 @@ func missingUnknownSubcmd(line1 string, cmd Cmd) string {
 		fmt.Fprintf(b, format, name, subcmds[name].Desc)
 	}
 	return b.String()
+}
+
+// FuncTypeErr means a Subcmd's F field has a type that does not match the function signature implied by its Params field.
+type FuncTypeErr struct {
+	// Got is the type of the F field.
+	Got reflect.Type
+
+	// Want is the expected function type implied by the Params field.
+	// Note: for simplicity, this includes the optional error return,
+	// even if the type in Got does not
+	// (which is not, in itself, an error).
+	Want reflect.Type
+}
+
+func (e FuncTypeErr) Error() string {
+	return fmt.Sprintf("function has type %v, want %v", e.Got, e.Want)
+}
+
+// NumArgsErr is the error when too many or too few arguments are supplied to Run for a Subcmd's function.
+type NumArgsErr struct {
+	// Got is the number of arguments supplied.
+	Got int
+
+	// Want is the number of function parameters expected.
+	Want int
+}
+
+func (e NumArgsErr) Error() string {
+	return fmt.Sprintf("got %d arguments but function takes %d parameters", e.Got, e.Want)
+}
+
+// ParamDefaultErr is the error when a Param has a default value that is not of the correct type.
+type ParamDefaultErr struct {
+	Param Param
+}
+
+func (e ParamDefaultErr) Error() string {
+	return fmt.Sprintf("default value %v is not of type %v", e.Param.Default, e.Param.Type)
 }

--- a/errors.go
+++ b/errors.go
@@ -232,19 +232,6 @@ func (e FuncTypeErr) Error() string {
 	return fmt.Sprintf("function has type %v, want %v", e.Got, e.Want)
 }
 
-// NumArgsErr is the error when too many or too few arguments are supplied to Run for a Subcmd's function.
-type NumArgsErr struct {
-	// Got is the number of arguments supplied.
-	Got int
-
-	// Want is the number of function parameters expected.
-	Want int
-}
-
-func (e NumArgsErr) Error() string {
-	return fmt.Sprintf("got %d arguments but function takes %d parameters", e.Got, e.Want)
-}
-
 // ParamDefaultErr is the error when a Param has a default value that is not of the correct type.
 type ParamDefaultErr struct {
 	Param Param

--- a/parse.go
+++ b/parse.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// The length of the resulting slice is len(params)+2.
 func parseArgs(ctx context.Context, params []Param, args []string) ([]reflect.Value, error) {
 	fs, ptrs, positional, err := ToFlagSet(params)
 	if err != nil {

--- a/parseenv_test.go
+++ b/parseenv_test.go
@@ -2,6 +2,7 @@ package subcmd
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 )
 
@@ -13,7 +14,16 @@ func TestParseEnv(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv(EnvVar, string(j))
+
+	// Can't use t.Setenv, introduced in Go 1.17,
+	// because we're on Go 1.14 and don't want to break callers unnecessarily.
+	oldval, ok := os.LookupEnv(EnvVar)
+	if ok {
+		defer os.Setenv(EnvVar, oldval)
+	} else {
+		defer os.Unsetenv(EnvVar)
+	}
+	os.Setenv(EnvVar, string(j))
 
 	type s struct {
 		Foo string `json:"foo"`

--- a/parseenv_test.go
+++ b/parseenv_test.go
@@ -1,0 +1,37 @@
+package subcmd
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseEnv(t *testing.T) {
+	j, err := json.Marshal(map[string]interface{}{
+		"foo": "bar",
+		"baz": 42,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvVar, string(j))
+
+	type s struct {
+		Foo string `json:"foo"`
+		Baz int    `json:"baz"`
+	}
+
+	var (
+		got  s
+		want = s{
+			Foo: "bar",
+			Baz: 42,
+		}
+	)
+
+	if err := ParseEnv(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}

--- a/parseenv_test.go
+++ b/parseenv_test.go
@@ -15,15 +15,8 @@ func TestParseEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Can't use t.Setenv, introduced in Go 1.17,
-	// because we're on Go 1.14 and don't want to break callers unnecessarily.
-	oldval, ok := os.LookupEnv(EnvVar)
-	if ok {
-		defer os.Setenv(EnvVar, oldval)
-	} else {
-		defer os.Unsetenv(EnvVar)
-	}
-	os.Setenv(EnvVar, string(j))
+	restoreEnv := testSetenv(EnvVar, string(j))
+	defer restoreEnv()
 
 	type s struct {
 		Foo string `json:"foo"`

--- a/parseenv_test.go
+++ b/parseenv_test.go
@@ -2,7 +2,6 @@ package subcmd
 
 import (
 	"encoding/json"
-	"os"
 	"testing"
 )
 

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -1,0 +1,47 @@
+package subcmd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPrefix(t *testing.T) {
+	ctx := context.Background()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := os.Getenv("PATH")
+	path += ":" + filepath.Join(wd, "testdata")
+	t.Setenv("PATH", path)
+
+	t.Run("subcmd", func(t *testing.T) {
+		if err := Run(ctx, testPrefixMainCmd{}, []string{"subcmd", "a", "b", "c"}); err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("nosubcmd", func(t *testing.T) {
+		err := Run(ctx, testPrefixMainCmd{}, []string{"nosubcmd", "a", "b", "c"})
+		var u *UnknownSubcmdErr
+		switch {
+		case errors.As(err, &u):
+			// ok
+
+		case err != nil:
+			t.Error(err)
+
+		default:
+			t.Errorf("expected error of type %T, got nil", u)
+		}
+	})
+}
+
+type testPrefixMainCmd struct{}
+
+func (testPrefixMainCmd) Subcmds() Map   { return nil }
+func (testPrefixMainCmd) Prefix() string { return "foo-" }

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -17,7 +17,9 @@ func TestPrefix(t *testing.T) {
 	}
 	path := os.Getenv("PATH")
 	path += ":" + filepath.Join(wd, "testdata")
-	t.Setenv("PATH", path)
+
+	restoreEnv := testSetenv("PATH", path)
+	defer restoreEnv()
 
 	t.Run("subcmd", func(t *testing.T) {
 		if err := Run(ctx, testPrefixMainCmd{}, []string{"subcmd", "a", "b", "c"}); err != nil {

--- a/subcmd.go
+++ b/subcmd.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"reflect"
 	"sort"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -132,6 +133,33 @@ func (t Type) String() string {
 		return "[]string"
 	default:
 		return fmt.Sprintf("unknown type %d", t)
+	}
+}
+
+func (t Type) reflectType() reflect.Type {
+	switch t {
+	case Bool:
+		return reflect.TypeOf(false)
+	case Int:
+		return reflect.TypeOf(int(0))
+	case Int64:
+		return reflect.TypeOf(int64(0))
+	case Uint:
+		return reflect.TypeOf(uint(0))
+	case Uint64:
+		return reflect.TypeOf(uint64(0))
+	case String:
+		return reflect.TypeOf("")
+	case Float64:
+		return reflect.TypeOf(float64(0))
+	case Duration:
+		return reflect.TypeOf(time.Duration(0))
+	case contextType:
+		return reflect.TypeOf((*context.Context)(nil)).Elem()
+	case stringSliceType:
+		return reflect.TypeOf([]string(nil))
+	default:
+		panic(fmt.Sprintf("unknown type %d", t))
 	}
 }
 

--- a/subcmd.go
+++ b/subcmd.go
@@ -392,9 +392,8 @@ func Run(ctx context.Context, c Cmd, args []string) error {
 		return FuncTypeErr{Got: ft, Want: wantFuncTypeErr}
 	}
 
-	if numIn := ft.NumIn(); numIn != len(argvals) {
-		return NumArgsErr{Got: len(argvals), Want: numIn}
-	}
+	// Assert: len(argvals) == ft.NumIn()
+
 	for i, argval := range argvals {
 		if !argval.Type().AssignableTo(ft.In(i)) {
 			return fmt.Errorf("type of arg %d is %s, want %s", i, ft.In(i), argval.Type())

--- a/subcmd_test.go
+++ b/subcmd_test.go
@@ -332,12 +332,18 @@ func (cmd *command) xcmd(
 }
 
 func TestCommands(t *testing.T) {
+	baz := Subcmd{
+		F:    bazcmd,
+		Desc: "baz command",
+	}
+
 	got := Commands(
 		"foo", foocmd, "foo command", Params(
 			"a", Bool, false, "flag a",
 			"b", Int, 0, "flag b",
 		),
 		"bar", barcmd, "bar command", nil,
+		"baz", baz,
 	)
 	want := Map{
 		"foo": Subcmd{
@@ -359,6 +365,10 @@ func TestCommands(t *testing.T) {
 			F:    barcmd,
 			Desc: "bar command",
 		},
+		"baz": Subcmd{
+			F:    bazcmd,
+			Desc: "baz command",
+		},
 	}
 	if diff := cmp.Diff(want, got, fooopt, baropt); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
@@ -378,6 +388,7 @@ func (cmd *command) zcmd(_ context.Context, opt int, _ []string) error {
 
 func foocmd(context.Context, bool, int, []string) {}
 func barcmd(context.Context, []string)            {}
+func bazcmd(context.Context, []string)            {}
 
 var (
 	foocomparer = func(_, _ func(context.Context, bool, int, []string)) bool { return true }

--- a/testdata/foo-subcmd
+++ b/testdata/foo-subcmd
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo $SUBCMD_ENV

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,14 @@
+package subcmd
+
+import "os"
+
+// testSetenv sets the environment variable key to val and returns a function that restores the environment.
+// It's like "testing.T".Setenv but for older versions of Go.
+func testSetenv(key, val string) func() {
+	oldval, ok := os.LookupEnv(key)
+	os.Setenv(key, val)
+	if ok {
+		return func() { os.Setenv(key, oldval) }
+	}
+	return func() { os.Unsetenv(key) }
+}


### PR DESCRIPTION
This PR adds "external subcommands," the `Check` and `CheckMap` functions, and a number of error variables and types. It also expands the semantics of the `Commands` function.

## External subcommands

In a call to `Run(ctx, cmd, args)`, `args[0]` is the _name_ of a subcommand to execute from the `cmd.Subcmds` map. If _name_ does not appear in the map, the result is normally an `UnknownSubcmdErr` error.

But with this change, if `cmd` implements the `Prefixer` interface in addition to `Cmd`, then `cmd.Prefix` is called to get a _prefix_, and then an executable named _prefixname_ is sought in `$PATH`. If found, it's executed with the remaining `args` as arguments, and a JSON representation of `cmd` in the environment variable `SUBCMD_ENV` (which can be parsed with the new function `ParseEnv`).

This feature is patterned after command-line tools such as `git`, which has some built-in subcommands of its own, but which can be extended by putting an executable named `git-foo` in `$PATH` (to create subcommand `foo`).

## Check and CheckMap

These new functions perform various runtime type-safety checks on a `Subcmd` and a `Map`, respectively.

## Commands

The Command function previously required arguments in groups of four:

- subcommand name;
- function implementing the subcommand;
- short description;
- parameters as a `[]Param`.

With this change, a group may now also be a pair of arguments:

- subcommand name;
- `Subcmd` object.