### PR TITLE
Permit variadic functions and flag.Value-typed parameters

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 # Subcmd - command-line interfaces with subcommands and flags
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/bobg/subcmd.svg)](https://pkg.go.dev/github.com/bobg/subcmd)
-[![Go Report Card](https://goreportcard.com/badge/github.com/bobg/subcmd)](https://goreportcard.com/report/github.com/bobg/subcmd)
+[![Go Reference](https://pkg.go.dev/badge/github.com/bobg/subcmd/v2.svg)](https://pkg.go.dev/github.com/bobg/subcmd/v2)
+[![Go Report Card](https://goreportcard.com/badge/github.com/bobg/subcmd/v2)](https://goreportcard.com/report/github.com/bobg/subcmd/v2)
 [![Tests](https://github.com/bobg/subcmd/actions/workflows/go.yml/badge.svg)](https://github.com/bobg/subcmd/actions/workflows/go.yml)
 [![Coverage Status](https://coveralls.io/repos/github/bobg/subcmd/badge.svg?branch=master)](https://coveralls.io/github/bobg/subcmd?branch=master)
 

--- a/Readme.md
+++ b/Readme.md
@@ -17,13 +17,20 @@ command -globalopt subcommand -subopt1 FOO -subopt2 ARG1 ARG2
 
 Subcommands may have sub-subcommands and so on.
 Subcommands may also be implemented as separate executables.
-(See the documentation for [Prefixer](https://pkg.go.dev/github.com/bobg/subcmd/v2#Prefixer).)
 
 This is a layer on top of the standard Go `flag` package.
 
 ## Usage
 
 ```go
+import (
+  "context"
+  "database/sql"
+  "flag"
+
+  "github.com/bobg/subcmd/v2"
+)
+
 func main() {
   // Parse global flags normally.
   dbname := flag.String("db", "", "database connection string")

--- a/check.go
+++ b/check.go
@@ -67,7 +67,7 @@ func checkParam(param Param) error {
 	return nil
 }
 
-// CheckMap calls Check on each of the entries in the Map.
+// CheckMap calls [Check] on each of the entries in the Map.
 func CheckMap(m Map) error {
 	for name, subcmd := range m {
 		if err := Check(subcmd); err != nil {

--- a/check.go
+++ b/check.go
@@ -12,7 +12,7 @@ import (
 //   - It must return no more than one value;
 //   - If it returns a value, that value must be of type error;
 //   - It must take an initial context.Context parameter;
-//   - It must take a final []string parameter;
+//   - It must take a final []string or ...string parameter;
 //   - The length of subcmd.Params must match the number of parameters subcmd.F takes (not counting the initial context.Context and final []string parameters);
 //   - Each parameter in subcmd.Params must match the corresponding parameter in subcmd.F.
 //

--- a/check.go
+++ b/check.go
@@ -40,7 +40,7 @@ func checkFuncType(ft reflect.Type, params []Param) error {
 	for _, param := range params {
 		in = append(in, param.Type.reflectType())
 	}
-	in = append(in, reflect.TypeOf([]string(nil)))
+	in = append(in, strSliceType)
 
 	out := []reflect.Type{errType}
 

--- a/context.go
+++ b/context.go
@@ -16,7 +16,7 @@ func withFlagSet(ctx context.Context, fs *flag.FlagSet) context.Context {
 	return context.WithValue(ctx, fsKey, fs)
 }
 
-// FlagSet produces the *flag.FlagSet used in a call to a Subcmd function.
+// FlagSet produces the [flag.FlagSet] used in a call to a [Subcmd] function.
 func FlagSet(ctx context.Context) *flag.FlagSet {
 	val := ctx.Value(fsKey)
 	return val.(*flag.FlagSet)

--- a/err_test.go
+++ b/err_test.go
@@ -149,7 +149,7 @@ func TestParseErr(t *testing.T) {
 	err := Run(context.Background(), errtestcmd{}, []string{"a", "x"})
 	var perr ParseErr
 	if !errors.As(err, &perr) {
-		t.Errorf("got %T, want *ParseErr", err)
+		t.Errorf("got %v, want *ParseErr", err)
 	}
 }
 
@@ -169,6 +169,6 @@ func (errtestcmd) Subcmds() Map {
 	)
 }
 
-func errtestA(_ context.Context, _ []string) error { return nil }
-func errtestB(_ context.Context, _ []string) error { return nil }
-func errtestC(_ context.Context, _ []string) error { return nil }
+func errtestA(context.Context, bool, int, string, time.Duration, bool, []string) error { return nil }
+func errtestB(_ context.Context, _ []string) error                                     { return nil }
+func errtestC(_ context.Context, _ []string) error                                     { return nil }

--- a/errors.go
+++ b/errors.go
@@ -34,7 +34,7 @@ type UsageErr interface {
 	Detail() string
 }
 
-// MissingSubcmdErr is a usage error returned when Run is called with an empty `args` list.
+// MissingSubcmdErr is a usage error returned when [Run] is called with an empty args list.
 type MissingSubcmdErr struct {
 	pairs []subcmdPair
 	cmd   Cmd
@@ -44,7 +44,7 @@ func (e *MissingSubcmdErr) Error() string {
 	return fmt.Sprintf("missing subcommand, want one of: %s", strings.Join(subcmdNames(e.cmd), "; "))
 }
 
-// Detail implements Usage.
+// Detail implements [Usage].
 func (e *MissingSubcmdErr) Detail() string {
 	return missingUnknownSubcmd("Missing subcommand, want one of:", e.cmd)
 }
@@ -99,7 +99,7 @@ func (e *HelpRequestedErr) Error() string {
 	return fmt.Sprintf("subcommands are: %s", strings.Join(subcmdNames(e.cmd), "; "))
 }
 
-// Detail implements Usage.
+// Detail implements [Usage].
 func (e *HelpRequestedErr) Detail() string {
 	if e.name != "" {
 		// foo bar help baz
@@ -182,7 +182,7 @@ func (e *HelpRequestedErr) Detail() string {
 	return b.String()
 }
 
-// UnknownSubcmdErr is a usage error returned when an unknown subcommand name is passed to Run as args[0].
+// UnknownSubcmdErr is a usage error returned when an unknown subcommand name is passed to [Run] as args[0].
 type UnknownSubcmdErr struct {
 	pairs []subcmdPair
 	cmd   Cmd
@@ -193,7 +193,7 @@ func (e *UnknownSubcmdErr) Error() string {
 	return fmt.Sprintf(`unknown subcommand "%s", want one of: %s`, e.name, strings.Join(subcmdNames(e.cmd), "; "))
 }
 
-// Detail implements Usage.
+// Detail implements [Usage].
 func (e *UnknownSubcmdErr) Detail() string {
 	return missingUnknownSubcmd(fmt.Sprintf(`Unknown subcommand "%s", want one of:`, e.name), e.cmd)
 }
@@ -216,7 +216,7 @@ func missingUnknownSubcmd(line1 string, cmd Cmd) string {
 	return b.String()
 }
 
-// FuncTypeErr means a Subcmd's F field has a type that does not match the function signature implied by its Params field.
+// FuncTypeErr means a [Subcmd]'s F field has a type that does not match the function signature implied by its Params field.
 type FuncTypeErr struct {
 	// Got is the type of the F field.
 	Got reflect.Type
@@ -234,7 +234,7 @@ func (e FuncTypeErr) Error() string {
 	return fmt.Sprintf("function has type %v, want %v", e.Got, e.Want)
 }
 
-// ParamDefaultErr is the error when a Param has a default value that is not of the correct type.
+// ParamDefaultErr is the error when a [Param] has a default value that is not of the correct type.
 type ParamDefaultErr struct {
 	Param Param
 }

--- a/errors.go
+++ b/errors.go
@@ -225,7 +225,7 @@ type FuncTypeErr struct {
 	// Note: there are four variations on this type:
 	// variadic vs. non-variadic, and error-returning vs. non-error-returning.
 	// FuncTypeErr means a function matched none of those types,
-	// but for simplicity Want returns only one of them
+	// but for simplicity Want contains only one of them
 	// (the non-variadic, error-returning one).
 	Want reflect.Type
 }

--- a/errors.go
+++ b/errors.go
@@ -222,9 +222,11 @@ type FuncTypeErr struct {
 	Got reflect.Type
 
 	// Want is the expected function type implied by the Params field.
-	// Note: for simplicity, this includes the optional error return,
-	// even if the type in Got does not
-	// (which is not, in itself, an error).
+	// Note: there are four variations on this type:
+	// variadic vs. non-variadic, and error-returning vs. non-error-returning.
+	// FuncTypeErr means a function matched none of those types,
+	// but for simplicity Want returns only one of them
+	// (the non-variadic, error-returning one).
 	Want reflect.Type
 }
 

--- a/parse.go
+++ b/parse.go
@@ -264,9 +264,11 @@ func parseValuePos(args *[]string, argvals *[]reflect.Value, p Param) error {
 	return nil
 }
 
-// ToFlagSet produces a *flag.FlagSet from the given params,
-// plus a list of properly typed pointers in which to store the results of calling Parse on the FlagSet,
-// and a list of positional Params that are not part of the resulting FlagSet.
+// ToFlagSet takes a slice of [Param] and produces:
+//
+//   - a [flag.FlagSet],
+//   - a list of properly typed pointers (or in the case of a [Value]-typed Param, a [flag.Value]) in which to store the results of calling Parse on the FlagSet,
+//   - a list of positional [Param]s that are not part of the resulting FlagSet.
 //
 // On a successful return, len(ptrs)+len(positional) == len(params).
 func ToFlagSet(params []Param) (fs *flag.FlagSet, ptrs []reflect.Value, positional []Param, err error) {

--- a/subcmd.go
+++ b/subcmd.go
@@ -57,12 +57,20 @@ func subcmdNames(c Cmd) []string {
 }
 
 // Subcmd is one subcommand of a Cmd.
+//
+// The function Check can be used to check that F and the default values in Params
+// match the types specified in Params.
 type Subcmd struct {
 	// F is the function implementing the subcommand.
-	// Its signature must be func(context.Context, ..., []string) error,
-	// where the number and types of parameters between the context and the string slice
-	// is given by Params.
-	// The error return is optional.
+	// Its signature must be one of the following:
+	//
+	//   - func(context.Context, OPTS, []string)
+	//   - func(context.Context, OPTS, []string) error
+	//   - func(context.Context, OPTS, ...string)
+	//   - func(context.Context, OPTS, ...string) error
+	//
+	// where OPTS stands for a sequence of zero or more additional parameters
+	// corresponding to the types in Params.
 	F interface{}
 
 	// Params describes the parameters to F
@@ -172,6 +180,7 @@ func (t Type) reflectType() reflect.Type {
 //   - the list of parameters for the function, a slice of Param (which can be produced with the Params function).
 //
 // These are used to populate a Subcmd.
+// See Subcmd for a description of the requirements on the implementing function.
 //
 // A call like this:
 //
@@ -284,7 +293,7 @@ func Params(a ...interface{}) []Param {
 // The remaining values in args are parsed to populate those.
 //
 // After argument parsing,
-// the subcommand's function is invoked with a context object,
+// the subcommand's function is invoked with the given context object,
 // the flag and parameter values,
 // and a slice of the args remaining.
 //
@@ -306,6 +315,8 @@ func Params(a ...interface{}) []Param {
 //
 // If c is a Prefixer and the subcommand name is both unknown and not "help",
 // then an executable is sought in $PATH with c's prefix plus the subcommand name.
+// (For example, if c.Prefix() returns "foo-" and the subcommand name is "bar",
+// then the executable "foo-bar" is sought.)
 // If one is found,
 // it is executed with the remaining args as arguments,
 // and a JSON-marshaled copy of c in the environment variable SUBCMD_ENV

--- a/subcmd.go
+++ b/subcmd.go
@@ -24,7 +24,8 @@ var (
 )
 
 // Cmd is a command that has subcommands.
-// It tells Run how to parse its subcommands, and their flags and positional parameters,
+// It tells [Run] how to parse its subcommands,
+// and their flags and positional parameters,
 // and how to run them.
 type Cmd interface {
 	// Subcmds returns this Cmd's subcommands as a map,
@@ -33,20 +34,20 @@ type Cmd interface {
 	Subcmds() Map
 }
 
-// Prefixer is an optional additional interface that a Cmd can implement.
-// If it does, and a call to Run encounters an unknown subcommand,
+// Prefixer is an optional additional interface that a [Cmd] can implement.
+// If it does, and a call to [Run] encounters an unknown subcommand,
 // then before returning an error it will look for an executable in $PATH
 // whose name is Prefix() plus the subcommand name.
 // If it finds one,
 // it is executed with the remaining args as arguments,
 // and a JSON-marshaled copy of the Cmd in the environment variable SUBCMD_ENV
-// (that can be parsed by the subprocess using ParseEnv).
+// (that can be parsed by the subprocess using [ParseEnv]).
 type Prefixer interface {
 	Prefix() string
 }
 
-// Map is the type of the data structure returned by Cmd.Subcmds and by Commands.
-// It maps a subcommand name to its Subcmd structure.
+// Map is the type of the data structure returned by [Cmd.Subcmds] and by [Commands].
+// It maps a subcommand name to its [Subcmd] structure.
 type Map = map[string]Subcmd
 
 // Returns c's subcommand names as a sorted slice.
@@ -59,10 +60,12 @@ func subcmdNames(c Cmd) []string {
 	return result
 }
 
-// Subcmd is one subcommand of a Cmd.
+// Subcmd is one subcommand of a [Cmd],
+// and the value type in the [Map] returned by [Cmd.Subcmds].
 //
-// The function Check can be used to check that F and the default values in Params
-// match the types specified in Params.
+// The function [Check] can be used to check that the type of the F field
+// is a function with parameters matching those specified by the Params field,
+// and also that each Param has a default value of the correct type.
 type Subcmd struct {
 	// F is the function implementing the subcommand.
 	// Its signature must be one of the following:
@@ -74,17 +77,20 @@ type Subcmd struct {
 	//
 	// where OPTS stands for a sequence of zero or more additional parameters
 	// corresponding to the types in Params.
+	//
+	// A Param with type Value supplies a flag.Value to the function.
+	// It's up to the function to type-assert the flag.Value to a more-specific type to read the value it contains.
 	F interface{}
 
 	// Params describes the parameters to F
-	// (excluding the initial context.Context that F takes, and the final []string).
+	// (excluding the initial context.Context that F takes, and the final []string or ...string).
 	Params []Param
 
 	// Desc is a one-line description of this subcommand.
 	Desc string
 }
 
-// Param is one parameter of a Subcmd.
+// Param is one parameter of a [Subcmd].
 type Param struct {
 	// Name is the flag name for the parameter.
 	// Flags must have a leading "-", as in "-verbose".
@@ -97,21 +103,19 @@ type Param struct {
 
 	// Default is a default value for the parameter.
 	// Its type must be suitable for Type.
-	// As a special case,
-	// if Type is Value,
-	// then Default must be a flag.Value
-	// which encodes its own default.
+	// If Type is Value,
+	// then Default must be a flag.Value.
 	Default interface{}
 
 	// Doc is a docstring for the parameter.
 	Doc string
 }
 
-// Type is the type of a Param.
+// Type is the type of a [Param].
 type Type int
 
-// Possible Param types.
-// These correspond with the types in the standard flag package.
+// Possible [Param] types.
+// These correspond with the types in the standard [flag] package.
 const (
 	Bool Type = iota + 1
 	Int
@@ -124,7 +128,7 @@ const (
 	Value
 )
 
-// String returns the name of t.
+// String returns the name of a [Type].
 func (t Type) String() string {
 	switch t {
 	case Bool:
@@ -175,24 +179,25 @@ func (t Type) reflectType() reflect.Type {
 	}
 }
 
-// Commands is a convenience function for producing the Map
-// needed by an implementation of Cmd.Subcmd.
+// Commands is a convenience function for producing the [Map]
+// needed by an implementation of [Cmd.Subcmd].
 // It takes arguments in groups of two or four,
 // one group per subcommand.
 //
 // The first argument of a group is the subcommand's name, a string.
-// The second argument of a group may be a Subcmd,
+// The second argument of a group may be a [Subcmd],
 // making this a two-argument group.
+//
 // If it's not a Subcmd,
 // then this is a four-argument group,
 // whose second through fourth arguments are:
 //
 //   - the function implementing the subcommand;
 //   - a short description of the subcommand;
-//   - the list of parameters for the function, a slice of Param (which can be produced with the Params function).
+//   - the list of parameters for the function, a slice of [Param] (which can be produced with the [Params] function).
 //
 // These are used to populate a Subcmd.
-// See Subcmd for a description of the requirements on the implementing function.
+// See [Subcmd] for a description of the requirements on the implementing function.
 //
 // A call like this:
 //
@@ -233,6 +238,9 @@ func (t Type) reflectType() reflect.Type {
 //	     },
 //	   },
 //	}
+//
+// Note, if a parameter's type is [Value],
+// then its default value must be a [flag.Value].
 //
 // This function panics if the number or types of the arguments are wrong.
 func Commands(args ...interface{}) Map {
@@ -275,10 +283,14 @@ func Commands(args ...interface{}) Map {
 // It takes 4n arguments,
 // where n is the number of parameters.
 // Each group of four is:
-// - the name for the parameter, a string (e.g. "-verbose" for a -verbose flag);
-// - the type of the parameter, a Type constant;
-// - the default value of the parameter,
-// - the doc string for the parameter.
+//
+//   - the name for the parameter, a string (e.g. "-verbose" for a -verbose flag);
+//   - the type of the parameter, a [Type] constant;
+//   - the default value of the parameter,
+//   - the doc string for the parameter.
+//
+// Note, if a parameter's type is [Value],
+// then its default value must be a [flag.Value].
 //
 // This function panics if the number or types of the arguments are wrong.
 func Params(a ...interface{}) []Param {
@@ -304,26 +316,25 @@ func Params(a ...interface{}) []Param {
 // That subcommand specifies zero or more flags and zero or more positional parameters.
 // The remaining values in args are parsed to populate those.
 //
-// After argument parsing,
-// the subcommand's function is invoked with the given context object,
-// the flag and parameter values,
-// and a slice of the args remaining.
+// The subcommand's function is invoked with the given context object,
+// the parsed flag and positional-parameter values,
+// and a slice of the values remaining in args after parsing.
 //
-// Flags are parsed using a new flag.FlagSet,
+// Flags are parsed using a new [flag.FlagSet],
 // which is placed into the context object passed to the subcommand's function.
-// The FlagSet can be retrieved if needed with the FlagSet function.
+// The FlagSet can be retrieved if needed with the [FlagSet] function.
 // No flag.FlagSet is present if the subcommand has no flags.
 //
 // Flags are always optional, and have names beginning with "-".
 // Positional parameters may be required or optional.
 // Optional positional parameters have a trailing "?" in their names.
 //
-// Calling Run with an empty args slice produces a MissingSubcmdErr error.
+// Calling Run with an empty args slice produces a [MissingSubcmdErr] error.
 //
-// Calling Run with an unknown subcommand name in args[0] produces an UnknownSubcmdErr error,
+// Calling Run with an unknown subcommand name in args[0] produces an [UnknownSubcmdErr] error,
 // unless the unknown subcommand is "help",
-// in which case the result is a HelpRequestedErr,
-// or unless c is also a Prefixer.
+// in which case the result is a [HelpRequestedErr],
+// or unless c is also a [Prefixer].
 //
 // If c is a Prefixer and the subcommand name is both unknown and not "help",
 // then an executable is sought in $PATH with c's prefix plus the subcommand name.
@@ -332,10 +343,10 @@ func Params(a ...interface{}) []Param {
 // If one is found,
 // it is executed with the remaining args as arguments,
 // and a JSON-marshaled copy of c in the environment variable SUBCMD_ENV
-// (that can be parsed by the subprocess using ParseEnv).
+// (that can be parsed by the subprocess using [ParseEnv]).
 //
 // If there are not enough values in args to populate the subcommand's required positional parameters,
-// the result is ErrTooFewArgs.
+// the result is [ErrTooFewArgs].
 //
 // If argument parsing succeeds,
 // Run returns the error produced by calling the subcommand's function, if any.
@@ -435,9 +446,9 @@ func Run(ctx context.Context, c Cmd, args []string) error {
 	return errors.Wrapf(err, "running %s", name)
 }
 
-// EnvVar is the name of the environment variable used by Run to pass the JSON-encoded Cmd to a subprocess.
-// Use ParseEnv to decode it.
-// See Prefixer.
+// EnvVar is the name of the environment variable used by [Run] to pass the JSON-encoded [Cmd] to a subprocess.
+// Use [ParseEnv] to decode it.
+// See [Prefixer].
 const EnvVar = "SUBCMD_ENV"
 
 // ParseEnv parses the value of the SUBCMD_ENV environment variable,

--- a/subcmd.go
+++ b/subcmd.go
@@ -4,6 +4,7 @@ package subcmd
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,9 +16,11 @@ import (
 )
 
 var (
-	errType = reflect.TypeOf((*error)(nil)).Elem()
-	ctxType = reflect.TypeOf((*context.Context)(nil)).Elem()
-	strType = reflect.TypeOf("")
+	ctxType      = reflect.TypeOf((*context.Context)(nil)).Elem()
+	errType      = reflect.TypeOf((*error)(nil)).Elem()
+	strSliceType = reflect.TypeOf([]string(nil))
+	strType      = reflect.TypeOf("")
+	valueType    = reflect.TypeOf((*flag.Value)(nil)).Elem()
 )
 
 // Cmd is a command that has subcommands.
@@ -94,6 +97,10 @@ type Param struct {
 
 	// Default is a default value for the parameter.
 	// Its type must be suitable for Type.
+	// As a special case,
+	// if Type is Value,
+	// then Default must be a flag.Value
+	// which encodes its own default.
 	Default interface{}
 
 	// Doc is a docstring for the parameter.
@@ -114,6 +121,7 @@ const (
 	String
 	Float64
 	Duration
+	Value
 )
 
 // String returns the name of t.
@@ -135,6 +143,8 @@ func (t Type) String() string {
 		return "float64"
 	case Duration:
 		return "time.Duration"
+	case Value:
+		return "flag.Value"
 	default:
 		return fmt.Sprintf("unknown type %d", t)
 	}
@@ -158,6 +168,8 @@ func (t Type) reflectType() reflect.Type {
 		return reflect.TypeOf(float64(0))
 	case Duration:
 		return reflect.TypeOf(time.Duration(0))
+	case Value:
+		return valueType
 	default:
 		panic(fmt.Sprintf("unknown type %d", t))
 	}

--- a/value_test.go
+++ b/value_test.go
@@ -1,0 +1,84 @@
+package subcmd
+
+import (
+	"context"
+	"flag"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestValue(t *testing.T) {
+	c := valuetestcmd{
+		x:    valuetestvalue{result: []string{"x"}},
+		y:    valuetestvalue{result: []string{"y"}},
+		pos1: valuetestvalue{result: []string{"pos1"}},
+		pos2: valuetestvalue{result: []string{"pos2"}},
+	}
+
+	if err := Run(context.Background(), &c, []string{"a", "-x", "1,2,3", "4,5,6", "7,8", "9,10"}); err != nil {
+		t.Fatal(err)
+	}
+
+	want := valuetestcmd{
+		x:    valuetestvalue{result: []string{"1", "2", "3"}},
+		y:    valuetestvalue{result: []string{"y"}},
+		pos1: valuetestvalue{result: []string{"4", "5", "6"}},
+		pos2: valuetestvalue{result: []string{"7", "8"}},
+		rest: []string{"9,10"},
+	}
+	if !reflect.DeepEqual(c, want) {
+		t.Errorf("got %+v, want %+v", c, want)
+	}
+}
+
+type valuetestcmd struct {
+	x, y, pos1, pos2 valuetestvalue
+	rest             []string
+}
+
+func (c *valuetestcmd) Subcmds() Map {
+	return Commands(
+		"a", c.a, "", Params(
+			"-x", Value, &c.x, "",
+			"-y", Value, &c.y, "",
+			"pos1", Value, &c.pos1, "",
+			"pos2", Value, &c.pos2, "",
+		),
+	)
+}
+
+func (c *valuetestcmd) a(_ context.Context, x, y, pos1, pos2 flag.Value, rest []string) error {
+	if x, _ := x.(*valuetestvalue); x != nil {
+		c.x = *x
+	}
+	if y, _ := y.(*valuetestvalue); y != nil {
+		c.y = *y
+	}
+	if pos1, _ := pos1.(*valuetestvalue); pos1 != nil {
+		c.pos1 = *pos1
+	}
+	if pos2, _ := pos2.(*valuetestvalue); pos2 != nil {
+		c.pos2 = *pos2
+	}
+	c.rest = rest
+	return nil
+}
+
+type valuetestvalue struct {
+	result []string
+}
+
+var _ flag.Value = &valuetestvalue{}
+
+func (v *valuetestvalue) String() string {
+	if v == nil {
+		return ""
+	}
+	return strings.Join(v.result, ",")
+}
+
+func (v *valuetestvalue) Set(s string) error {
+	v.result = strings.Split(s, ",")
+	return nil
+}

--- a/variadic_test.go
+++ b/variadic_test.go
@@ -1,0 +1,72 @@
+package subcmd
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func TestVariadic(t *testing.T) {
+	args := []string{"a", "-x", "7", "b", "c", "d"}
+
+	for _, variadic := range []bool{false, true} {
+		t.Run(strconv.FormatBool(variadic), func(t *testing.T) {
+			c := vtestcmd{variadic: variadic}
+			if err := Run(context.Background(), &c, args); err != nil {
+				t.Fatal(err)
+			}
+
+			want := vtestcmd{
+				variadic: variadic,
+				x:        7,
+				pos:      "b",
+				rest:     []string{"c", "d"},
+			}
+			if !reflect.DeepEqual(c, want) {
+				t.Errorf("got %+v, want %+v", c, want)
+			}
+		})
+	}
+}
+
+type vtestcmd struct {
+	// In.
+	variadic bool
+
+	// Out.
+	x    int
+	pos  string
+	rest []string
+}
+
+func (c *vtestcmd) Subcmds() Map {
+	var f interface{}
+
+	if c.variadic {
+		f = c.v
+	} else {
+		f = c.a
+	}
+
+	return Commands(
+		"a", f, "", Params(
+			"-x", Int, 0, "",
+			"pos", String, "", "",
+		),
+	)
+}
+
+func (c *vtestcmd) a(ctx context.Context, x int, pos string, rest []string) error {
+	c.x = x
+	c.pos = pos
+	c.rest = rest
+	return nil
+}
+
+func (c *vtestcmd) v(ctx context.Context, x int, pos string, rest ...string) error {
+	c.x = x
+	c.pos = pos
+	c.rest = rest
+	return nil
+}


### PR DESCRIPTION
This PR adds support for subcommand-implementing functions whose parameter lists end in `...string` as an alternative to `[]string`.

It also adds support for [flag.Value](https://pkg.go.dev/flag#Value)-typed parameters.

It also adds support for multiple leading hyphens in the `Param.Name` field; i.e., you can write `"-verbose"` or `"--verbose"` (or even `"---verbose"`) and it will mean the same thing: a flag named `verbose`, which at runtime will match a command-line option named `-verbose` or `--verbose` (per [the behavior of Go's standard flag package](https://pkg.go.dev/flag#hdr-Command_line_flag_syntax)).