### PR TITLE
Add the Copier type

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -208,10 +208,11 @@ func parseDurationPos(args *[]string, argvals *[]reflect.Value, p Param) error {
 }
 
 func parseValuePos(args *[]string, argvals *[]reflect.Value, p Param) error {
-	val, ok := p.Default.(flag.Value)
+	val, ok := p.Default.(ValueType)
 	if !ok {
-		return ParseErr{Err: fmt.Errorf("param %s is not a flag.Value", p.Name)}
+		return ParseErr{Err: fmt.Errorf("param %s is not a ValueType", p.Name)}
 	}
+	val = val.Copy()
 	if len(*args) > 0 {
 		if err := val.Set((*args)[0]); err != nil {
 			return ParseErr{Err: err}
@@ -358,7 +359,7 @@ func asDuration(val interface{}) time.Duration {
 // ToFlagSet takes a slice of [Param] and produces:
 //
 //   - a [flag.FlagSet],
-//   - a list of properly typed pointers (or in the case of a [Value]-typed Param, a [flag.Value]) in which to store the results of calling Parse on the FlagSet,
+//   - a list of properly typed pointers (or in the case of a [Value]-typed Param, a [ValueType]) in which to store the results of calling Parse on the FlagSet,
 //   - a list of positional Params that are not part of the resulting FlagSet.
 //
 // On a successful return, len(ptrs)+len(positional) == len(params).
@@ -404,11 +405,12 @@ func ToFlagSet(params []Param) (fs *flag.FlagSet, ptrs []reflect.Value, position
 			v = fs.Duration(name, asDuration(p.Default), p.Doc)
 
 		case Value:
-			val, ok := p.Default.(flag.Value)
+			val, ok := p.Default.(ValueType)
 			if !ok {
-				err = fmt.Errorf("param %s has type Value but default value %v is not a flag.Value", p.Name, p.Default)
+				err = fmt.Errorf("param %s has type Value but default value %v is not a ValueType", p.Name, p.Default)
 				return
 			}
+			val = val.Copy()
 			fs.Var(val, name, p.Doc)
 			v = val
 

--- a/subcmd.go
+++ b/subcmd.go
@@ -4,6 +4,7 @@ package subcmd
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -19,7 +20,7 @@ var (
 	errType      = reflect.TypeOf((*error)(nil)).Elem()
 	strSliceType = reflect.TypeOf([]string(nil))
 	strType      = reflect.TypeOf("")
-	valueType    = reflect.TypeOf((*ValueType)(nil)).Elem()
+	valueType    = reflect.TypeOf((*flag.Value)(nil)).Elem()
 )
 
 // Cmd is a command that has subcommands.
@@ -77,8 +78,8 @@ type Subcmd struct {
 	// where OPTS stands for a sequence of zero or more additional parameters
 	// corresponding to the types in Params.
 	//
-	// A Param with type Value supplies a [ValueType] to the function.
-	// It's up to the function to type-assert the ValueType to a more-specific type to read the value it contains.
+	// A Param with type Value supplies a [flag.Value] to the function.
+	// It's up to the function to type-assert the flag.Value to a more-specific type to read the value it contains.
 	F interface{}
 
 	// Params describes the parameters to F
@@ -103,7 +104,8 @@ type Param struct {
 	// Default is a default value for the parameter.
 	// Its type must be suitable for Type.
 	// If Type is Value,
-	// then Default must be a [ValueType].
+	// then Default must be a [flag.Value].
+	// It may optionally also be a [Copier], qv.
 	Default interface{}
 
 	// Doc is a docstring for the parameter.
@@ -147,7 +149,7 @@ func (t Type) String() string {
 	case Duration:
 		return "time.Duration"
 	case Value:
-		return "ValueType"
+		return "flag.Value"
 	default:
 		return fmt.Sprintf("unknown type %d", t)
 	}
@@ -239,7 +241,7 @@ func (t Type) reflectType() reflect.Type {
 //	}
 //
 // Note, if a parameter's type is [Value],
-// then its default value must be a [ValueType].
+// then its default value must be a [flag.Value].
 //
 // This function panics if the number or types of the arguments are wrong.
 func Commands(args ...interface{}) Map {
@@ -289,7 +291,7 @@ func Commands(args ...interface{}) Map {
 //   - the doc string for the parameter.
 //
 // Note, if a parameter's type is [Value],
-// then its default value must be a [ValueType].
+// then its default value must be a [flag.Value].
 //
 // This function panics if the number or types of the arguments are wrong.
 func Params(a ...interface{}) []Param {

--- a/subcmd.go
+++ b/subcmd.go
@@ -4,7 +4,6 @@ package subcmd
 import (
 	"context"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -20,7 +19,7 @@ var (
 	errType      = reflect.TypeOf((*error)(nil)).Elem()
 	strSliceType = reflect.TypeOf([]string(nil))
 	strType      = reflect.TypeOf("")
-	valueType    = reflect.TypeOf((*flag.Value)(nil)).Elem()
+	valueType    = reflect.TypeOf((*ValueType)(nil)).Elem()
 )
 
 // Cmd is a command that has subcommands.
@@ -78,8 +77,8 @@ type Subcmd struct {
 	// where OPTS stands for a sequence of zero or more additional parameters
 	// corresponding to the types in Params.
 	//
-	// A Param with type Value supplies a flag.Value to the function.
-	// It's up to the function to type-assert the flag.Value to a more-specific type to read the value it contains.
+	// A Param with type Value supplies a [ValueType] to the function.
+	// It's up to the function to type-assert the ValueType to a more-specific type to read the value it contains.
 	F interface{}
 
 	// Params describes the parameters to F
@@ -104,7 +103,7 @@ type Param struct {
 	// Default is a default value for the parameter.
 	// Its type must be suitable for Type.
 	// If Type is Value,
-	// then Default must be a flag.Value.
+	// then Default must be a [ValueType].
 	Default interface{}
 
 	// Doc is a docstring for the parameter.
@@ -148,7 +147,7 @@ func (t Type) String() string {
 	case Duration:
 		return "time.Duration"
 	case Value:
-		return "flag.Value"
+		return "ValueType"
 	default:
 		return fmt.Sprintf("unknown type %d", t)
 	}
@@ -240,7 +239,7 @@ func (t Type) reflectType() reflect.Type {
 //	}
 //
 // Note, if a parameter's type is [Value],
-// then its default value must be a [flag.Value].
+// then its default value must be a [ValueType].
 //
 // This function panics if the number or types of the arguments are wrong.
 func Commands(args ...interface{}) Map {
@@ -290,7 +289,7 @@ func Commands(args ...interface{}) Map {
 //   - the doc string for the parameter.
 //
 // Note, if a parameter's type is [Value],
-// then its default value must be a [flag.Value].
+// then its default value must be a [ValueType].
 //
 // This function panics if the number or types of the arguments are wrong.
 func Params(a ...interface{}) []Param {

--- a/value.go
+++ b/value.go
@@ -1,8 +1,0 @@
-package subcmd
-
-import "flag"
-
-type ValueType interface {
-	flag.Value
-	Copy() ValueType
-}

--- a/value.go
+++ b/value.go
@@ -1,0 +1,8 @@
+package subcmd
+
+import "flag"
+
+type ValueType interface {
+	flag.Value
+	Copy() ValueType
+}

--- a/value_test.go
+++ b/value_test.go
@@ -2,7 +2,7 @@ package subcmd
 
 import (
 	"context"
-	"flag"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -32,12 +32,32 @@ func TestValue(t *testing.T) {
 	}
 }
 
+func TestDifferentValues(t *testing.T) {
+	dflt := &valuetestvalue{result: []string{"dflt"}}
+	cmd := new(valuetestcmd)
+	cmd.subcmds = Commands(
+		"b", cmd.differentValues, "", Params(
+			"x", Value, dflt, "",
+			"y", Value, dflt, "",
+		),
+	)
+	if err := Run(context.Background(), cmd, []string{"b", "res1", "res2"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 type valuetestcmd struct {
 	x, y, pos1, pos2 valuetestvalue
 	rest             []string
+
+	subcmds Map
 }
 
 func (c *valuetestcmd) Subcmds() Map {
+	if c.subcmds != nil {
+		return c.subcmds
+	}
+
 	return Commands(
 		"a", c.a, "", Params(
 			"-x", Value, &c.x, "",
@@ -48,7 +68,7 @@ func (c *valuetestcmd) Subcmds() Map {
 	)
 }
 
-func (c *valuetestcmd) a(_ context.Context, x, y, pos1, pos2 flag.Value, rest []string) error {
+func (c *valuetestcmd) a(_ context.Context, x, y, pos1, pos2 ValueType, rest []string) error {
 	if x, _ := x.(*valuetestvalue); x != nil {
 		c.x = *x
 	}
@@ -65,11 +85,29 @@ func (c *valuetestcmd) a(_ context.Context, x, y, pos1, pos2 flag.Value, rest []
 	return nil
 }
 
+func (c *valuetestcmd) differentValues(_ context.Context, xv, yv ValueType, _ []string) error {
+	x, ok := xv.(*valuetestvalue)
+	if !ok {
+		return fmt.Errorf("unexpected type %T for x", xv)
+	}
+	y, ok := yv.(*valuetestvalue)
+	if !ok {
+		return fmt.Errorf("unexpected type %T for y", yv)
+	}
+	if len(x.result) != 1 || x.result[0] != "res1" {
+		return fmt.Errorf("unexpected x value %v", x.result)
+	}
+	if len(y.result) != 1 || y.result[0] != "res2" {
+		return fmt.Errorf("unexpected y value %v", y.result)
+	}
+	return nil
+}
+
 type valuetestvalue struct {
 	result []string
 }
 
-var _ flag.Value = &valuetestvalue{}
+var _ ValueType = &valuetestvalue{}
 
 func (v *valuetestvalue) String() string {
 	if v == nil {
@@ -81,4 +119,12 @@ func (v *valuetestvalue) String() string {
 func (v *valuetestvalue) Set(s string) error {
 	v.result = strings.Split(s, ",")
 	return nil
+}
+
+func (v *valuetestvalue) Copy() ValueType {
+	result := &valuetestvalue{
+		result: make([]string, len(v.result)),
+	}
+	copy(result.result, v.result)
+	return result
 }

--- a/value_test.go
+++ b/value_test.go
@@ -2,6 +2,7 @@ package subcmd
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"reflect"
 	"strings"
@@ -68,7 +69,7 @@ func (c *valuetestcmd) Subcmds() Map {
 	)
 }
 
-func (c *valuetestcmd) a(_ context.Context, x, y, pos1, pos2 ValueType, rest []string) error {
+func (c *valuetestcmd) a(_ context.Context, x, y, pos1, pos2 flag.Value, rest []string) error {
 	if x, _ := x.(*valuetestvalue); x != nil {
 		c.x = *x
 	}
@@ -85,7 +86,7 @@ func (c *valuetestcmd) a(_ context.Context, x, y, pos1, pos2 ValueType, rest []s
 	return nil
 }
 
-func (c *valuetestcmd) differentValues(_ context.Context, xv, yv ValueType, _ []string) error {
+func (c *valuetestcmd) differentValues(_ context.Context, xv, yv flag.Value, _ []string) error {
 	x, ok := xv.(*valuetestvalue)
 	if !ok {
 		return fmt.Errorf("unexpected type %T for x", xv)
@@ -107,8 +108,6 @@ type valuetestvalue struct {
 	result []string
 }
 
-var _ ValueType = &valuetestvalue{}
-
 func (v *valuetestvalue) String() string {
 	if v == nil {
 		return ""
@@ -121,7 +120,7 @@ func (v *valuetestvalue) Set(s string) error {
 	return nil
 }
 
-func (v *valuetestvalue) Copy() ValueType {
+func (v *valuetestvalue) Copy() flag.Value {
 	result := &valuetestvalue{
 		result: make([]string, len(v.result)),
 	}


### PR DESCRIPTION
This PR adds the new `Copier` type, an optional interface that `flag.Value`s can implement to permit reuse of default values. Fixes #7. 